### PR TITLE
Read env variables from within the config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ RUN \
 FROM ubuntu AS local-testnet
 ENTRYPOINT ["/sparrow"]
 COPY --from=builder /sparrow /sparrow
+COPY --from=builder /app/config.example.yaml /config.example.yaml

--- a/config/config.go
+++ b/config/config.go
@@ -67,7 +67,13 @@ func KeyringPassword(envKey string) string {
 
 func FromReader(r io.Reader) (Root, error) {
 	var cnf Root
-	err := yaml.NewDecoder(r).Decode(&cnf)
+	rawBody, err := io.ReadAll(r)
+	if err != nil {
+		return Root{}, err
+	}
+	str := string(rawBody)
+	str = os.ExpandEnv(str)
+	err = yaml.Unmarshal([]byte(str), &cnf)
 	if err != nil {
 		return Root{}, err
 	}


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/85

# Background

Sometimes it's easier to inject certain values through the env variables. This PR makes it possible to write the env variable in the config and it would read the value from it.

# Testing completed

- [x] made sure that the tests are passing
