### PR TITLE
Generic attesting to events from sparrow

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/gogo/protobuf/proto"
+	"github.com/palomachain/sparrow/attest"
 	chain "github.com/palomachain/sparrow/client"
 	"github.com/palomachain/sparrow/client/paloma"
 	"github.com/palomachain/sparrow/config"
@@ -21,6 +22,8 @@ var (
 	_config       *config.Root
 	_configPath   string
 	_palomaClient *paloma.Client
+
+	_attestRegistry *attest.Registry
 )
 
 func Relayer() *relayer.Relayer {
@@ -29,6 +32,7 @@ func Relayer() *relayer.Relayer {
 		_relayer = relayer.New(
 			*Config(),
 			*PalomaClient(),
+			AttestRegistry(),
 		)
 	}
 	return _relayer
@@ -88,6 +92,13 @@ func PalomaClient() *paloma.Client {
 		}
 	}
 	return _palomaClient
+}
+
+func AttestRegistry() *attest.Registry {
+	if _attestRegistry == nil {
+		_attestRegistry = attest.NewRegistry()
+	}
+	return _attestRegistry
 }
 
 func defaultValue[T comparable](proposedVal T, defaultVal T) T {

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -1,0 +1,29 @@
+package attest
+
+import "context"
+
+type Request interface{}
+
+type Evidence interface {
+	Bytes() ([]byte, error)
+}
+
+type Registry struct {
+	r map[string]Attestor
+}
+
+func (r *Registry) Register(queueTypeName string, att Attestor) {
+	r.r[queueTypeName] = att
+}
+
+func (r *Registry) Execute(ctx context.Context, queueTypeName string, req Request) (Evidence, error) {
+	att, ok := r.r[queueTypeName]
+	if !ok {
+		return nil, nil
+	}
+	return att.ProvideEvidence(ctx, req)
+}
+
+type Attestor interface {
+	ProvideEvidence(ctx context.Context, req Request) (Evidence, error)
+}

--- a/attest/attest.go
+++ b/attest/attest.go
@@ -12,6 +12,12 @@ type Registry struct {
 	r map[string]Attestor
 }
 
+func NewRegistry() *Registry {
+	return &Registry{
+		r: make(map[string]Attestor),
+	}
+}
+
 func (r *Registry) Register(queueTypeName string, att Attestor) {
 	r.r[queueTypeName] = att
 }

--- a/client/paloma/client.go
+++ b/client/paloma/client.go
@@ -153,6 +153,7 @@ type BroadcastMessageSignatureIn struct {
 	ID            uint64
 	QueueTypeName string
 	Signature     []byte
+	ExtraData     []byte
 }
 
 // BroadcastMessageSignatures takes a list of signatures that need to be sent over to the chain.
@@ -229,6 +230,7 @@ func broadcastMessageSignatures(
 			Id:            sig.ID,
 			QueueTypeName: sig.QueueTypeName,
 			Signature:     sig.Signature,
+			ExtraData:     sig.ExtraData,
 		})
 	}
 	msg := &consensus.MsgAddMessagesSignatures{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/gogo/protobuf v1.3.3
-	github.com/palomachain/utils v0.2.0
+	github.com/palomachain/utils v0.2.1-0.20220517093034-66182f410d9e
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cobra v1.4.0
 	github.com/strangelove-ventures/lens v0.3.1-0.20220329150126-16b15e90cf34

--- a/go.sum
+++ b/go.sum
@@ -707,6 +707,8 @@ github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/palomachain/utils v0.2.0 h1:vcagL2KQ+FMd7j0ePAh0oc13wgYuQOg4hdFIhsW/sw4=
 github.com/palomachain/utils v0.2.0/go.mod h1:f1HAitrlailP5kHUAveTJvYB8JeQPpFyAexc/sLVBWM=
+github.com/palomachain/utils v0.2.1-0.20220517093034-66182f410d9e h1:lBmUhq687Vp9DNaMTaNfKaAKMlXILGaUvV6AHrIwiqg=
+github.com/palomachain/utils v0.2.1-0.20220517093034-66182f410d9e/go.mod h1:f1HAitrlailP5kHUAveTJvYB8JeQPpFyAexc/sLVBWM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -1,7 +1,10 @@
 package relayer
 
 import (
+	"context"
+
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/palomachain/sparrow/attest"
 	"github.com/palomachain/sparrow/client/paloma"
 	"github.com/palomachain/sparrow/client/terra"
 	"github.com/palomachain/sparrow/config"
@@ -13,6 +16,10 @@ type palomaClienter interface {
 	Keyring() keyring.Keyring
 }
 
+type attestExecutor interface {
+	Execute(context.Context, string, attest.Request) (attest.Evidence, error)
+}
+
 type Relayer struct {
 	config config.Root
 
@@ -20,14 +27,17 @@ type Relayer struct {
 	palomaClient paloma.Client
 	terraClients map[string]terra.Client
 
+	attestExecutor attestExecutor
+
 	signingKeyAddress string
 	validatorAddress  string
 }
 
-func New(config config.Root, palomaClient paloma.Client) *Relayer {
+func New(config config.Root, palomaClient paloma.Client, attestExecutor attestExecutor) *Relayer {
 	return &Relayer{
-		config:       config,
-		palomaClient: palomaClient,
+		config:         config,
+		palomaClient:   palomaClient,
+		attestExecutor: attestExecutor,
 	}
 }
 

--- a/relayer/sign_messages_for_execution.go
+++ b/relayer/sign_messages_for_execution.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/palomachain/sparrow/attest"
 	"github.com/palomachain/sparrow/client/paloma"
 	consensus "github.com/palomachain/sparrow/types/paloma/x/consensus/types"
 	"github.com/palomachain/utils/signing"
@@ -53,13 +52,10 @@ func (c consensusMessageQueueType[T]) queryMessagesForSigning(
 			r.palomaClient.Keyring(),
 			signingKeyAddress,
 		),
+		r.attestExecutor,
 		valAddress,
 		c.queue(),
 	)
-}
-
-type attestExecutor interface {
-	Execute(context.Context, string, attest.Request) (attest.Evidence, error)
 }
 
 func signMessagesForExecution[T consensus.Signable](


### PR DESCRIPTION
# Related Github tickets

- https://github.com/palomachain/paloma/issues/106

# Background

We need to made it possible for sparrow to attest to events from _"outside"_ world. This is a generic solution which allows us to do just that.

# Testing completed

- ensured that tests are working
